### PR TITLE
fix(F160): the irrigation-expense day index matches SCS's corrected weekly schedule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,3 +34,6 @@
 
 ## Deferred / parked
 - Consuming a peer earnings API instead of reading `farm.money` directly: parked; direct read is correct and simpler for v1.
+
+## 2026-08-14 (Fred): F160 - the irrigation-expense day index matches SCS's corrected schedule
+- [x] CropStressIrrigationExpense mirrored SCS's old day-of-week read (env.currentDayInPeriod, pinned at 1 on a default save). It now derives the index from the monotonic day modulo 7, matching SCS's F160 fix, so the accrual lands on the days SCS actually runs. DAILY_DEPRECIATION_PER_SYSTEM stays 0 (balance-pass number).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.5.56</version>
+    <version>1.1.5.57</version>
 
     <title>
         <en>Tax Mod</en>

--- a/src/integrations/CropStressIrrigationExpense.lua
+++ b/src/integrations/CropStressIrrigationExpense.lua
@@ -26,16 +26,16 @@ CropStressIrrigationExpense = {}
 -- and wired, not fabricated (brief OI-2 / OI-3).
 CropStressIrrigationExpense.DAILY_DEPRECIATION_PER_SYSTEM = 0
 
--- Day-of-week index 1..7, matching SCS IrrigationManager:hourlyScheduleCheck
--- (env.currentDayInPeriod, fallback (currentDay % 7) + 1, clamped) so our
--- accrual lands on the same days SCS actually runs a system.
+-- Day-of-week index 1..7, matching SCS IrrigationManager:dayOfWeekIndex (F160),
+-- so our accrual lands on the same days SCS actually runs a system. Derived from
+-- the monotonic day modulo 7, never from env.currentDayInPeriod: the base game
+-- computes currentDayInPeriod as (currentDay - 1) % daysPerPeriod + 1 and
+-- daysPerPeriod defaults to 1, so on a default save it is always 1.
 local function dayOfWeekIndex(env)
     if env == nil then return 1 end
-    local dow = env.currentDayInPeriod
-    if dow == nil then
-        local currentDay = env.currentDay or env.currentMonotonicDay or 0
-        dow = (currentDay % 7) + 1
-    end
+    local currentDay = env.currentDay or env.currentMonotonicDay or 1
+    if type(currentDay) ~= "number" or currentDay < 1 then currentDay = 1 end
+    local dow = ((currentDay - 1) % 7) + 1
     if dow < 1 or dow > 7 then dow = 1 end
     return dow
 end


### PR DESCRIPTION
F160 companion: TaxMod's irrigation-expense day index now matches SCS's corrected weekly schedule.

CropStressIrrigationExpense mirrored SCS IrrigationManager's day-of-week derivation so the daily accrual lands on the same days SCS actually runs a system. The old read used env.currentDayInPeriod, which the base game pins at 1 on a default save (daysPerPeriod defaults to 1), so the expense would have accrued on every day while the system ran on a subset, or on the wrong days entirely. It now derives the 1..7 index from the monotonic day modulo 7, the same formula SCS uses after its F160 fix.

The shipped value DAILY_DEPRECIATION_PER_SYSTEM stays 0 (neutral, a balance-pass number), so this is a correctness fix to the wiring that activates when the balance pass sets it. Built and deployed as 1.1.5.57.
