### PR TITLE
fix(tax): nil-guard the settings path so early saves cannot abort the load

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-30
 
 ## Near-term (next release cycle)
+- [x] Load-crash nil guard on the settings path (2026-08-18): `getSettingsPath()` guarded on `missionInfo` existing but not on `missionInfo.savegameDirectory`, which is nil during the shared I3D load, so any early `saveSettings()`/`loadSettings()` call threw "attempt to concatenate nil with string" and aborted the load (reported on SoilFertilizer #857 / #858, the crash with the full RF suite). The guard now covers `savegameDirectory`, and both callers already no-op on a nil path. One line.
 - [x] MP tax bug (F15): DONE on development (commit 8ff9989d). Annual-tax `addMoney` gated on `getIsServer`; `applyDailyTax` only accumulates. Re-verify the release asset matches dev HEAD (asset modDesc was mislabeled 1.1.4.1).
 - [x] StateLedger `TaxMod_Data` bridge live (delegate-when-present); `modSettings/` save kept as the safety copy. Shipped v1.1.5.0. (Fully retiring the FS22 path is a later cleanup.)
 - [~] SettingsHub: 5 settings registered (selfPersisted), shipped v1.1.5.0; removing TaxSettingsUI.lua + UIHelper.lua (ESC injection) still open.

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [ ] Decide: keep or remove `returnPercentage`.
 
 ## Bugs
+- [x] Load crash, nil savegameDirectory concat (2026-08-18, PR fix/tax-savegame-dir-nil): `getSettingsPath()` (main.lua:162-166) guarded on `g_currentMission.missionInfo` but concatenated `missionInfo.savegameDirectory`, which is nil during the shared I3D load, so any early settings save/load threw "attempt to concatenate nil with string" and aborted the mission load. Reported as the full-RF-suite load crash on SoilFertilizer #857 / #858. Now guarded on `savegameDirectory`; both callers already no-op on a nil path. 499 SCS + SF suites unaffected; no TaxMod suite exists, the staged Lua syntax gate passes.
 - [x] MP tax bug (F15): RESOLVED on development (commit 8ff9989d, 2026-07-01). The annual-tax `addMoney` is gated on `getIsServer` (main.lua:226); `applyDailyTax` only accumulates and moves no money. Note: the mislabeled pre-release asset (modDesc 1.1.4.1) predates this, so re-verify against dev HEAD before release.
 - [x] TX-001 / TX-002: additional TaxMod bugs fixed in 2026-07-26 bug sweep, merged to main.
 

--- a/main.lua
+++ b/main.lua
@@ -160,7 +160,8 @@ local function _migrateLegacyAccrual()
 end
 
 local function getSettingsPath()
-    if g_currentMission and g_currentMission.missionInfo then
+    if g_currentMission and g_currentMission.missionInfo
+       and g_currentMission.missionInfo.savegameDirectory then
         return g_currentMission.missionInfo.savegameDirectory .. "/modSettings/FS25_TaxMod.xml"
     end
 end


### PR DESCRIPTION
## What

One-line fix for the full-RF-suite load crash reported on SoilFertilizer #857 and #858.

TaxMod `getSettingsPath()` (`main.lua:162-166`) guarded on `g_currentMission.missionInfo` existing, then concatenated `missionInfo.savegameDirectory`, which is still nil during the shared I3D load. Any settings save or load that fired in that window threw `attempt to concatenate nil with string` and aborted the mission load. That is the hard error in both logs; SoilFertilizer's DeferredInit warning is a benign fill-type retry, not the crash.

The guard now also requires `missionInfo.savegameDirectory`, and both callers already no-op when the path is nil.

## Verified

- Lua 5.1 syntax gate passes on the staged file.
- Zip built. Not yet deployed (game running, zip locked) and not yet tested in game.
