### PR TITLE
Release v1.1.6.0 (corrects the 1.1.5.60 version number)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the repo's git history and README.
 
 ---
 
-## [1.1.5.60] - 2026-08-26
+## [1.1.6.0] - 2026-08-26
 
 ### Fixed
 - Settings path nil-guard: an early settings save during the shared I3D load could concatenate the savegame folder path before it existed and abort the load (the full-suite load crash, SF issues #857/#858). The path is now nil-guarded (PR #34).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.5.60</version>
+    <version>1.1.6.0</version>
 
     <title>
         <en>Tax Mod</en>


### PR DESCRIPTION
Tax Mod v1.1.6.0

Same tested build as the brief 1.1.5.60 release, with a corrected version number.

- Fixed a settings save during load that could abort the game load with the full suite installed
- Cleared the HUD toggle default key binding so it ships clean
- Economy scaling now follows the shared difficulty options
- HUD styling and layout improvements

No save migration needed.
