### PR TITLE
Hide leftover Esc eight-row hairlines

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -31,6 +31,7 @@ source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscModules.lu
 source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfPdaMenuPage.lua")
 source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscBootstrap.lua")
 source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/RfEscUiDebugger.lua")
+source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/TaxGuideDialog.lua")
 source((TaxModModDirectory or g_currentModDirectory) .. "src/gui/TaxRfPdaGuest.lua")
 
 FS25TaxMod = FS25TaxMod or {}

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -4,7 +4,7 @@
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/NMC-TBone/xml-schema/main/modDesc.xsd">
 
     <author>TisonK</author>
-    <version>1.1.6.29</version>
+    <version>1.1.6.32</version>
 
     <title>
         <en>Tax Mod</en>

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -233,6 +233,11 @@ function RfEscModules:registerModule(def)
         onOpenConsultant = def.onOpenConsultant,
         onOpenSchedule = def.onOpenSchedule,
         onOpenHelp = def.onOpenHelp,
+        -- BUILD 19:15: the shared Esc sheet's row click. registerModule rebuilds the descriptor field
+        -- by field, so a handler that is not named here is silently dropped and the control is dead.
+        -- That is what happened to onOpenFullMarket, onOpenConsultant, onPivotRemote, onLightTick,
+        -- onMoverChanged and onPageStep before it.
+        onSheetRow = def.onSheetRow,
         onPaintConsultant = def.onPaintConsultant,
         -- Same trap again, BUILD 15:46: the CS guest registers onPivotRemote on
         -- its module def (CsRfPdaGuest.lua) but it was missing here, so it was

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -701,6 +701,18 @@ function RfPdaMenuPage:initialize()
             self:onClickHelpCs()
         end
     }
+    -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): ONE generic Help footer for the eight wave-2
+    -- modules. It never names a dialog: it asks the active guest to open its own Field Guide, so each
+    -- companion ships and owns its own help and a door hosted by any mod routes to the right one.
+    -- Soil keeps btnHelp and Crop Stress keeps btnHelpCs, which point at their own guides.
+    self.btnHelpFw = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
+        text = tr("rf_pda_btn_help", "Help"),
+        callback = function()
+            self:onClickHelpFw()
+        end
+    }
 
     -- Back only. Help is Soil-only and _syncHostGuestChrome adds it when the Soil
     -- module is the active one; seeding it here leaked Help onto every module's
@@ -1678,9 +1690,15 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- header and empty hint go dark on every refresh; NpcRfPdaGuest.onShow alone shows them, so
     -- Income / Dairy / Depot never inherit a live list. Nil-safe: thin doors have no such ids.
     -- BUILD 12:05: plus the two NPC detail cards (rfFwRosterDetailCard / rfFwFavorDetailCard).
+    -- BUILD 17:21: rfFwSheetBox joins the list. No host ever calls a guest onHide, so the shared
+    -- scrolling table has to go dark here or the module that showed it last keeps its rows on
+    -- screen under the next module's headers.
     for _, id in ipairs({ "rfFwRosterBox", "rfFwFavorBox", "rfFwFavEmpty",
                           "rfFwFavColGroup", "rfFwFavColWho", "rfFwFavColWhat", "rfFwFavColUrgency",
-                          "rfFwRosterDetailCard", "rfFwFavorDetailCard" }) do
+                          "rfFwRosterDetailCard", "rfFwFavorDetailCard", "rfFwSheetBox",
+                          -- BUILD 19:15: the selected-row band goes dark with its sheet, so a row
+                          -- read on Depot can never sit under another module's headers.
+                          "rfFwSheetBand" }) do
         local el = self:getDescendantById(id)
         if el ~= nil and type(el.setVisible) == "function" then
             el:setVisible(false)
@@ -1931,12 +1949,14 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     end
     -- BUILD 12:05 (George CLOSED DESIGN 09:45): Market footer is Back only; the Esc full-Market
     -- door is gone (Prices / Events / Contracts are the whole Market on this page).
+    -- BUILD 19:15: Back + Help for the eight wave-2 modules (Market, Worker Costs, Pro Staff and the
+    -- five framework pages). The Help entry is the generic one; the guest decides which guide opens.
     if isMd then
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isWc then
-        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Back only. Hire / Fire live on the page
+        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Hire / Fire live on the page
         -- (wcBtnHireN / wcBtnFireN); Open Worker Manager is off the Esc footer.
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isCs then
         -- BUILD Help restore 2026-08-12: Back + Help. Consultant chip stays off footer.
         self.menuButtonInfo = { self.btnBack, self.btnHelpCs }
@@ -1949,6 +1969,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         -- Both dialogs stay registered and still open from the PDA/joiner; only the
         -- duplicate bottom-bar buttons go, since the cards now carry that content.
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    elseif isFw or activeId == "prostaff" then
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     else
         self.menuButtonInfo = { self.btnBack }
     end
@@ -3382,10 +3404,42 @@ local function resolveListRowIndex(element)
         if el.rowDataIndex ~= nil then
             return el.rowDataIndex
         end
+        -- BUILD 19:15: rowDataIndex is stamped by THIS page's own populate, so it exists only while
+        -- the host is still the list's data source. A list a guest has taken over - the shared Esc
+        -- sheet - never carries it, and the click resolved to nil. The engine stamps
+        -- element.indexInSection on every populated cell and reads that same field back as the
+        -- clicked row, so it is the row number either way. Index 0 is a section header, never a row.
+        if type(el.indexInSection) == "number" and el.indexInSection > 0 and el.isEmptyCell ~= true then
+            return el.indexInSection
+        end
         el = el.parent
         guard = guard + 1
     end
     return nil
+end
+
+--- BUILD 19:15 (George CLOSED DESIGN 18:55 item 2): a click on the shared Esc table. The engine hands
+--- the clicked cell to the callback; resolveListRowIndex walks up to the row's own rowDataIndex, and
+--- the index goes to whichever guest is showing. A guest without onSheetRow is a quiet no-op, which is
+--- what Income wants: it has no band.
+function RfPdaMenuPage:onClickFwSheetRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onSheetRow) == "function" then
+        pcall(active.onSheetRow, index)
+    end
+end
+
+--- BUILD 19:15 (item 5): the generic Help footer. Every wave-2 guest publishes onOpenHelp and owns its
+--- own Field Guide dialog inside its own mod, so this never names one.
+function RfPdaMenuPage:onClickHelpFw()
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onOpenHelp) == "function" then
+        pcall(active.onOpenHelp, self.rfHostPlaceholder or self)
+    end
 end
 
 function RfPdaMenuPage:onClickFieldRow(element)
@@ -3569,5 +3623,18 @@ end
 
 function RfPdaMenuPage:onClickMdNcDays(element)
     _mdGuestCall(self, "onNcDays", self.rfHostPlaceholder or self, element)
+end
+
+--- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal on the Contracts page, then cancel
+--- it. mdCtRow1..5 are invisible hit targets laid over the five contract rows, so the engine hands
+--- the clicked Button to the callback and the guest reads the row number off its id; the pick is
+--- stored as a contract id, never a row index. Cancel is ONE chip (mdCancelBtn), and the guest owns
+--- every gate: BetterContracts stand-down, "is the pick still an open deal", and the request itself.
+function RfPdaMenuPage:onClickMdCtRow(element)
+    _mdGuestCall(self, "onContractRow", self.rfHostPlaceholder or self, element)
+end
+
+function RfPdaMenuPage:onClickMdCancel()
+    _mdGuestCall(self, "onCancelContract", self.rfHostPlaceholder or self)
 end
 

--- a/src/gui/TaxGuideDialog.lua
+++ b/src/gui/TaxGuideDialog.lua
@@ -1,0 +1,279 @@
+-- =========================================================
+-- Tax Field Guide - Field Guide
+-- =========================================================
+-- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): every Realistic Farming Esc page gets its own
+-- guide, in its own mod, opened from the shared Help footer through this guest's onOpenHelp. The
+-- chrome is SoilGuideDialog's so all of them read as one family; only the words differ.
+-- Rows are { t = "H" | "B" | "S" | "COL", v = "text" }: header, body, spacer, column break.
+-- =========================================================
+
+---@class TaxGuideDialog
+TaxGuideDialog = TaxGuideDialog or {}
+local TaxGuideDialog_mt = Class(TaxGuideDialog, ScreenElement)
+
+local GUIDE_MOD_DIR = (TaxModModDirectory or g_currentModDirectory)
+
+TaxGuideDialog.INSTANCE = nil
+TaxGuideDialog.GUI_NAME = "TaxGuideDialog"
+
+TaxGuideDialog.SUBTITLES = {
+    "Overview - what the tax year does to your farm",
+    "Status Page - reading the pause page line by line",
+    "Settings & FAQ - options, controls and common questions",
+}
+
+TaxGuideDialog.PAGE1 = {
+    { t="H", v="WHAT THIS MOD DOES" },
+    { t="B", v="Tax Mod puts a yearly tax bill on your farm." },
+    { t="B", v="Nothing is taken out of your account day to" },
+    { t="B", v="day. A bill builds up all year instead, and" },
+    { t="B", v="it is settled once, in March." },
+    { t="S", v=" " },
+    { t="H", v="THE TAX YEAR" },
+    { t="B", v="Once each in-game day the mod looks at your" },
+    { t="B", v="farm balance. If the balance is above the" },
+    { t="B", v="minimum balance, a small share of it is" },
+    { t="B", v="added to this year's bill. No money moves." },
+    { t="S", v=" " },
+    { t="B", v="In December a tax advisory message tells you" },
+    { t="B", v="what March is likely to cost and what share" },
+    { t="B", v="of your balance that is." },
+    { t="S", v=" " },
+    { t="B", v="In March the bill is settled. A percentage" },
+    { t="B", v="of the built-up bill is taken, you are told" },
+    { t="B", v="the amount, and the bill resets to zero for" },
+    { t="B", v="the new year." },
+    { t="COL", v="" },
+    { t="H", v="THE PAUSE PAGE" },
+    { t="B", v="Press Esc and open the Realistic Farming" },
+    { t="B", v="tab. Pick Tax in the module list on the left" },
+    { t="B", v="to bring up this mod's page." },
+    { t="S", v=" " },
+    { t="B", v="The page is a status block, not a table." },
+    { t="B", v="Eight short lines fill two columns on the" },
+    { t="B", v="right, with a summary line underneath them." },
+    { t="S", v=" " },
+    { t="B", v="It is a read-only glance. Nothing on this" },
+    { t="B", v="page ever moves money or changes a setting." },
+    { t="S", v=" " },
+    { t="H", v="WHERE ELSE TO LOOK" },
+    { t="B", v="The Tax HUD shows the same figures on screen" },
+    { t="B", v="while you play, plus a short list of the" },
+    { t="B", v="most recent tax events." },
+    { t="S", v=" " },
+    { t="B", v="Settings sit in the game settings under a" },
+    { t="B", v="Tax Mod section. See the last tab." },
+}
+
+TaxGuideDialog.PAGE2 = {
+    { t="H", v="THE LEFT COLUMN" },
+    { t="B", v="A short help text sits at the top left. It" },
+    { t="B", v="tells the same story in a sentence or two." },
+    { t="S", v=" " },
+    { t="B", v="Under it is the list of Realistic Farming" },
+    { t="B", v="modules you have installed. Click Tax to" },
+    { t="B", v="bring up the tax lines. The selector above" },
+    { t="B", v="the list steps through the same modules." },
+    { t="S", v=" " },
+    { t="H", v="THE EIGHT STATUS LINES" },
+    { t="B", v="Tax: whether the system is on or off." },
+    { t="B", v="Accumulated bill: what this year has built" },
+    { t="B", v="up so far." },
+    { t="B", v="Projected March payment: what the March" },
+    { t="B", v="settlement would cost at today's figure." },
+    { t="B", v="Percent of balance: that payment as a share" },
+    { t="B", v="of the money you hold right now." },
+    { t="COL", v="" },
+    { t="B", v="Next: the payment month or the advisory" },
+    { t="B", v="month, whichever comes first, with the" },
+    { t="B", v="number of months to go." },
+    { t="B", v="Lifetime paid: every tax payment this save" },
+    { t="B", v="has ever made." },
+    { t="B", v="Companion ledger: credits and debits other" },
+    { t="B", v="mods have recorded here. It reads none yet" },
+    { t="B", v="until something records one." },
+    { t="B", v="Days taxed: how many days have added to the" },
+    { t="B", v="bill so far." },
+    { t="S", v=" " },
+    { t="H", v="THE SUMMARY LINE" },
+    { t="B", v="Below the eight lines sits one line with" },
+    { t="B", v="three figures: the daily rate, the March" },
+    { t="B", v="rate and the minimum balance." },
+    { t="S", v=" " },
+    { t="B", v="The daily rate and the March rate are two" },
+    { t="B", v="different settings. The daily one grows the" },
+    { t="B", v="bill. The March one decides how much of that" },
+    { t="B", v="bill you actually pay." },
+    { t="S", v=" " },
+    { t="B", v="The ledger totals are bookkeeping only. They" },
+    { t="B", v="never change what you owe." },
+}
+
+TaxGuideDialog.PAGE3 = {
+    { t="H", v="SETTINGS" },
+    { t="B", v="Open the game settings and scroll the" },
+    { t="B", v="general settings down to the Tax Mod" },
+    { t="B", v="section. Five controls sit there." },
+    { t="S", v=" " },
+    { t="B", v="Enable Tax Mod turns the system on or off." },
+    { t="B", v="Tax Rate sets the daily share: Low is one" },
+    { t="B", v="percent, Medium two, High three." },
+    { t="B", v="Annual Tax Rate sets the March share: Low is" },
+    { t="B", v="two percent, Medium five, High ten." },
+    { t="B", v="Notifications shows the in-game messages." },
+    { t="B", v="Show Tax HUD shows or hides the overlay." },
+    { t="S", v=" " },
+    { t="B", v="Settings are saved with your savegame." },
+    { t="COL", v="" },
+    { t="H", v="CONTROLS" },
+    { t="B", v="The mod ships with no keys assigned. Open" },
+    { t="B", v="Options then Controls and look for Toggle" },
+    { t="B", v="Tax HUD and Tax HUD Edit Mode." },
+    { t="S", v=" " },
+    { t="B", v="In edit mode, drag the panel with the left" },
+    { t="B", v="mouse button, drag a corner to resize, drag" },
+    { t="B", v="a side edge to change the width, then press" },
+    { t="B", v="the right mouse button to finish. The layout" },
+    { t="B", v="is kept with your savegame." },
+    { t="S", v=" " },
+    { t="H", v="COMMON QUESTIONS" },
+    { t="B", v="Nothing was added today. Your balance was" },
+    { t="B", v="under the minimum balance, or the system is" },
+    { t="B", v="switched off." },
+    { t="S", v=" " },
+    { t="B", v="March cost less than the bill said. Only a" },
+    { t="B", v="share of the built-up bill is charged." },
+    { t="S", v=" " },
+    { t="B", v="The returned total stays at zero. Refunds" },
+    { t="B", v="are not paid out in this version." },
+    { t="S", v=" " },
+    { t="B", v="The page says the tax manager is not ready." },
+    { t="B", v="Give the save a moment to finish loading." },
+}
+
+TaxGuideDialog.PAGE_CONTENT = { TaxGuideDialog.PAGE1, TaxGuideDialog.PAGE2, TaxGuideDialog.PAGE3 }
+
+-- -- Constructor ------------------------------------------
+
+function TaxGuideDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or TaxGuideDialog_mt)
+    self._contentLineEls = {}
+    self._currentPage = 1
+    return self
+end
+
+--- Loads the dialog into g_gui once. Safe to call twice, and safe to call when some other path has
+--- already registered the same name.
+function TaxGuideDialog.register(modDirectory)
+    if g_gui == nil then return end
+    if g_gui.guis ~= nil and g_gui.guis[TaxGuideDialog.GUI_NAME] ~= nil then return end
+    if modDirectory ~= nil then GUIDE_MOD_DIR = modDirectory end
+    if GUIDE_MOD_DIR == nil then return end
+    TaxGuideDialog.INSTANCE = TaxGuideDialog.new()
+    local ok, err = pcall(function()
+        g_gui:loadGui(GUIDE_MOD_DIR .. "xml/gui/TaxGuideDialog.xml", TaxGuideDialog.GUI_NAME, TaxGuideDialog.INSTANCE)
+    end)
+    if not ok then
+        print("[Tax] TaxGuideDialog: loadGui failed: " .. tostring(err))
+        TaxGuideDialog.INSTANCE = nil
+    end
+end
+
+function TaxGuideDialog.show()
+    if g_gui == nil then return end
+    local loaded = g_gui.guis ~= nil and g_gui.guis[TaxGuideDialog.GUI_NAME] ~= nil
+    if not loaded then
+        TaxGuideDialog.register(GUIDE_MOD_DIR)
+        loaded = g_gui.guis ~= nil and g_gui.guis[TaxGuideDialog.GUI_NAME] ~= nil
+    end
+    if not loaded then return end
+    g_gui:showDialog(TaxGuideDialog.GUI_NAME)
+end
+
+-- -- Lifecycle --------------------------------------------
+
+function TaxGuideDialog:onGuiSetupFinished()
+    TaxGuideDialog:superClass().onGuiSetupFinished(self)
+    self._elCol1 = self:getDescendantById("taxGuide_col1")
+    self._elCol2 = self:getDescendantById("taxGuide_col2")
+    self._elSubtitle = self:getDescendantById("taxGuide_subtitle")
+end
+
+function TaxGuideDialog:onOpen()
+    TaxGuideDialog:superClass().onOpen(self)
+    self._currentPage = 1
+    self:_selectPage(1)
+end
+
+function TaxGuideDialog:onClose()
+    TaxGuideDialog:superClass().onClose(self)
+    self:_clearContent()
+    self._currentPage = 1
+end
+
+-- -- Tabs -------------------------------------------------
+
+function TaxGuideDialog:onClickTab1() self:_selectPage(1) end
+function TaxGuideDialog:onClickTab2() self:_selectPage(2) end
+function TaxGuideDialog:onClickTab3() self:_selectPage(3) end
+
+function TaxGuideDialog:_selectPage(pageNum)
+    if self._currentPage == pageNum and #self._contentLineEls > 0 then return end
+    self:_clearContent()
+    self._currentPage = pageNum
+    if self._elSubtitle ~= nil then
+        self._elSubtitle:setText(TaxGuideDialog.SUBTITLES[pageNum] or "")
+    end
+    self:_buildContent(pageNum)
+end
+
+-- -- Content ----------------------------------------------
+
+function TaxGuideDialog:_buildContent(pageNum)
+    local profileH = g_gui:getProfile("taxGuide_colHeader")
+    local profileB = g_gui:getProfile("taxGuide_colBody")
+    local profileS = g_gui:getProfile("taxGuide_colSpacer")
+    if not profileH or not profileB then
+        print("[Tax] TaxGuideDialog: column profiles not found")
+        return
+    end
+    local content = TaxGuideDialog.PAGE_CONTENT[pageNum]
+    if content == nil then return end
+    local currentBox = self._elCol1
+    for _, row in ipairs(content) do
+        if row.t == "COL" then
+            if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+            currentBox = self._elCol2
+        elseif currentBox ~= nil then
+            local profile = (row.t == "H") and profileH
+                         or (row.t == "S") and profileS
+                         or profileB
+            if profile ~= nil then
+                local el = TextElement.new()
+                el:loadProfile(profile, true)
+                el:setText(row.v or "")
+                currentBox:addElement(el)
+                el:onGuiSetupFinished()
+                table.insert(self._contentLineEls, { box = currentBox, el = el })
+            end
+        end
+    end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+function TaxGuideDialog:_clearContent()
+    for _, entry in ipairs(self._contentLineEls or {}) do
+        if entry.box ~= nil then
+            entry.box:removeElement(entry.el)
+        end
+    end
+    self._contentLineEls = {}
+    if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+-- -- Button -----------------------------------------------
+
+function TaxGuideDialog:onClickClose()
+    g_gui:closeDialogByName(TaxGuideDialog.GUI_NAME)
+end

--- a/src/gui/TaxRfPdaGuest.lua
+++ b/src/gui/TaxRfPdaGuest.lua
@@ -344,6 +344,15 @@ function TaxRfPdaGuest.onHide(container)
     restoreStatusBand(container)
 end
 
+--- BUILD 19:15: the Esc Help footer asks whichever module is showing to open its own guide, so
+--- every companion ships and owns its own help instead of borrowing Soil's.
+---@param container table|nil
+function TaxRfPdaGuest.onOpenHelp(container)
+    if TaxGuideDialog ~= nil and type(TaxGuideDialog.show) == "function" then
+        TaxGuideDialog.show()
+    end
+end
+
 function TaxRfPdaGuest.tryRegister()
     if RfEscBootstrap ~= nil then
         if MOD_DIR == nil then
@@ -353,6 +362,12 @@ function TaxRfPdaGuest.tryRegister()
                 profilesXml = MOD_DIR .. "xml/gui/rfEscProfiles.xml",
                 iconPath = "textures/ui/menuIcon.dds",
             })
+            -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): load this mod's Field Guide at the
+            -- same moment the door itself loads. A GUI loaded from a mod directory later, once the
+            -- mod's own file system context has closed, fails to open.
+            if TaxGuideDialog ~= nil and type(TaxGuideDialog.register) == "function" then
+                pcall(TaxGuideDialog.register, MOD_DIR)
+            end
             if not doorOk then print("[Tax] TaxRfPdaGuest: WARNING ensureDoor failed (will retry)") end
         end
     end
@@ -368,6 +383,7 @@ function TaxRfPdaGuest.tryRegister()
             isAvailable = function() return getTax() ~= nil end,
             onShow = TaxRfPdaGuest.onShow,
             onHide = TaxRfPdaGuest.onHide,
+            onOpenHelp = TaxRfPdaGuest.onOpenHelp,
         })
         if ok then
             _registered = true

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -622,54 +622,92 @@
                                  take it with an inline size rather than one profile per orientation. Declared
                                  before the cells so text paints over them. Per-cell hasFrame would have been 144
                                  frame rects for the same picture. -->
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px" visible="false"/>
                             <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -548px" size="1120px 20px" text=""/>
+                            <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): the shared table scrolls. ONE SmoothList
+                                 under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the
+                                 hang fence), the NPC Favor nest, the sheet's own 28px pitch and the same four column
+                                 X as rfFwColA..D, so the headers above it still line up. Painted by whichever Table
+                                 guest is showing (Income, Depot); hidden by default and hidden again on every host
+                                 refresh, so no module inherits another's rows. The 32 rfFwRow* cells above stay
+                                 declared and unused: Dairy, NPC Favor and Pro Staff each hide them by id, and a door
+                                 must never lose an id a shipped guest still names. -->
+                            <!-- BUILD 19:15 (George CLOSED DESIGN 18:55): the sheet fills the bay like the Soil field
+                                 list - 480 tall, 48px rows, 18px cells - so ten full rows read at a glance instead of
+                                 eight cramped ones. Bottom sits at -540; rfFwMore follows at -548 and rfFwHintTable at
+                                 -576, and nothing in this block goes below -740, which is what keeps the Pro Staff
+                                 Buy / Run strip at -748 clear. Cell X and widths are untouched so rfFwColA..D still
+                                 head their own columns. The ListItem carries the row click; the host resolves the row
+                                 index and hands it to whichever guest is showing. -->
+                            <GuiElement profile="RF_FwListBox" id="rfFwSheetBox" position="10px -60px" size="1120px 480px" visible="false">
+                                <SmoothList id="rfFwSheetList" profile="RF_FwSheetList" size="1112px 480px" handleFocus="false"
+                                            startClipperElementName="rfFwSheetStart" endClipperElementName="rfFwSheetEnd">
+                                    <ListItem profile="RF_FwSheetItem" height="48px" onClick="onClickFwSheetRow">
+                                        <Bitmap profile="RF_RowBg" name="alternating"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetA" position="0px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetB" position="300px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetC" position="600px 0px" size="220px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetD" position="840px 0px" size="272px 48px"/>
+                                    </ListItem>
+                                </SmoothList>
+                                <Bitmap profile="RF_SheetStartClipper" name="rfFwSheetStart"/>
+                                <Bitmap profile="RF_SheetStopClipper" name="rfFwSheetEnd"/>
+                                <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                    <Slider profile="fs25_listSlider" dataElementId="rfFwSheetList" hideParentWhenEmpty="true"/>
+                                </ThreePartBitmap>
+                            </GuiElement>
+                            <!-- BUILD 19:15: the readout for the row the player clicked. Text only, no chip. Hidden by
+                                 default and hidden again on every host refresh beside rfFwSheetBox, so it can never
+                                 carry one module's row onto another module's page. The Depot guest fills it; Income
+                                 has no band and its onSheetRow is a no-op. -->
+                            <Text profile="RF_SheetBand" id="rfFwSheetBand" position="10px -664px" size="1120px 72px"
+                                  textMaxNumLines="3" textVerticalAlignment="top" visible="false" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12): the rfFwPagePrev / rfFwPageNext row pager is gone;
                                  the NPC Favor tables scroll (rfFwRosterList / rfFwFavorList below). The host keyEvent page
                                  belt (. / , keys) still serves a guest that registers onPageStep (Dairy cards). -->
@@ -689,7 +727,7 @@
                                     visible="false" text="" onClick="onClickPsFlush"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -576px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12, Ash 00:06): NPC Favor scrollable tables. Two SmoothLists
                                  under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the hang fence),
@@ -1504,6 +1542,20 @@
                                 <Text profile="RF_HintText" id="mdCtMore" textSize="13px" position="10px -186px" size="530px 20px" text=""/>
                                 <Text profile="RF_HintText" id="mdContractsEmpty" textSize="13px" position="10px -62px" size="530px 44px"
                                       textMaxNumLines="2" visible="false" text=""/>
+                                <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal, then Cancel it. The five
+                                     hit targets sit ON the row bands and paint nothing (RF_CtRowHit); they are declared
+                                     after the row Texts so the transparent button draws over the text without hiding it.
+                                     ONE Cancel chip, never one per row. handleFocus="false" and the profile's
+                                     isTriggerableByGlobalAction="false" are the overlay-chip law: SPACE never confirms it. -->
+                                <Button profile="RF_CtRowHit" id="mdCtRow1" position="10px -62px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow2" position="10px -86px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow3" position="10px -110px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow4" position="10px -134px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow5" position="10px -158px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Text profile="RF_HintText" id="mdCtSelected" textSize="13px" position="10px -212px" size="530px 20px" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdCancelBtn" position="10px -238px" size="170px 32px" handleFocus="false" visible="false" text="" onClick="onClickMdCancel"/>
+                                <Text profile="RF_HintText" id="mdCancelHint" textSize="13px" position="190px -234px" size="350px 40px"
+                                      textMaxNumLines="2" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="mdNewContractCard" position="580px 0px" size="550px 344px">
                                 <Text profile="RF_SectionTitle" id="mdNewContractTitle" position="10px -6px" size="530px 22px" text=""/>

--- a/xml/gui/TaxGuideDialog.xml
+++ b/xml/gui/TaxGuideDialog.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    Tax Field Guide - Field Guide
+    3 tabs. Content is built in Lua and swapped per tab (one column pair).
+    Chrome copied from SoilGuideDialog so every Realistic Farming guide reads the same.
+    Controller: TaxGuideDialog
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="taxGuide_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <GuiElement profile="fs25_dialogContentContainer">
+
+      <Text profile="fs25_dialogTitle" id="taxGuide_title" text="Tax Field Guide" position="0px -28px"/>
+
+      <BoxLayout profile="taxGuide_tabRow" position="0px -66px">
+        <Button profile="taxGuide_tab" id="taxGuide_tab1" text="Overview" onClick="onClickTab1"/>
+        <Button profile="taxGuide_tab" id="taxGuide_tab2" text="Status Page" onClick="onClickTab2"/>
+        <Button profile="taxGuide_tab" id="taxGuide_tab3" text="Settings &amp; FAQ" onClick="onClickTab3"/>
+      </BoxLayout>
+
+      <Text profile="taxGuide_subtitle" id="taxGuide_subtitle" text="" position="0px -110px"/>
+
+      <GuiElement profile="taxGuide_colPanel" position="-253px -138px">
+        <Bitmap profile="taxGuide_colBg" position="0px 0px"/>
+        <BoxLayout profile="taxGuide_col" id="taxGuide_col1" position="0px -8px"/>
+      </GuiElement>
+
+      <GuiElement profile="taxGuide_colPanel" position="253px -138px">
+        <Bitmap profile="taxGuide_colBgAlt" position="0px 0px"/>
+        <BoxLayout profile="taxGuide_col" id="taxGuide_col2" position="0px -8px"/>
+      </GuiElement>
+
+    </GuiElement>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+
+    <Profile name="taxGuide_bg" extends="fs25_dialogBg">
+      <size value="1120px 930px"/>
+    </Profile>
+
+    <Profile name="taxGuide_tabRow" extends="emptyPanel" with="anchorTopCenter">
+      <size value="960px 38px"/>
+      <flowDirection value="horizontal"/>
+      <elementSpacing value="10px"/>
+    </Profile>
+
+    <!-- The guide tabs and Close stay buttonOK: dialog chrome, not Esc overlay chips. -->
+    <Profile name="taxGuide_tab" extends="buttonOK">
+      <size value="174px 36px"/>
+      <textSize value="11px"/>
+      <textUpperCase value="true"/>
+    </Profile>
+
+    <Profile name="taxGuide_subtitle" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="960px 22px"/>
+      <textSize value="11px"/>
+      <textColor value="0.85 0.75 0.30 0.90"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="taxGuide_colPanel" extends="emptyPanel" with="anchorTopCenter">
+      <size value="510px 630px"/>
+    </Profile>
+    <Profile name="taxGuide_colBg" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.08 0.08 0.12 0.90"/>
+    </Profile>
+    <Profile name="taxGuide_colBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.06 0.10 0.14 0.90"/>
+    </Profile>
+
+    <Profile name="taxGuide_col" extends="emptyPanel" with="anchorTopCenter">
+      <size value="494px 614px"/>
+      <flowDirection value="vertical"/>
+      <useFullVisibility value="false"/>
+      <alignmentX value="left"/>
+      <elementSpacing value="3px"/>
+    </Profile>
+
+    <Profile name="taxGuide_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 22px"/>
+      <textSize value="15px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="taxGuide_colBody" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 19px"/>
+      <textSize value="14px"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="taxGuide_colSpacer" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 10px"/>
+      <textSize value="8px"/>
+      <textColor value="0.0 0.0 0.0 0.0"/>
+    </Profile>
+
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -729,6 +729,49 @@
         <textVerticalAlignment value="middle"/>
     </Profile>
 
+    <!-- BUILD 17:21: the shared Esc table list. 28px rows are the sheet's own pitch, so the four
+         column headers above the box still line up; the clippers are 12px because the engine's own
+         are 39px, sized for the 420px roster box. -->
+    <Profile name="RF_FwSheetList" extends="RF_SmoothList">
+        <size value="1112px 480px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 19:15: the Soil field-list family - 48px rows and 18px cells - so the shared table reads
+         at the same weight as the Soil list instead of a denser one. -->
+    <Profile name="RF_FwSheetItem" extends="RF_ListRow">
+        <height value="48px"/>
+    </Profile>
+    <Profile name="RF_FwSheetCell" extends="RF_FwListCell">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="1"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- 24px is proportional for a 480px box the way the engine's own 39px is for the 420px roster. -->
+    <Profile name="RF_SheetStartClipper" extends="fs25_secondaryMenuStartClipper">
+        <height value="24px"/>
+    </Profile>
+    <Profile name="RF_SheetStopClipper" extends="fs25_secondaryMenuStopClipper">
+        <height value="24px"/>
+    </Profile>
+    <!-- BUILD 19:15: the selected-row readout under the sheet. Three lines of hint text, top aligned. -->
+    <Profile name="RF_SheetBand" extends="RF_HintText">
+        <textSize value="18px"/>
+        <textMaxNumLines value="3"/>
+        <textVerticalAlignment value="top"/>
+    </Profile>
+
+    <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): an invisible per-row hit target for the Esc Market
+         contracts rows. It extends the pivot chip so the overlay-chip law's guards come with it
+         (hideKeyboardGlyph, isTriggerableByGlobalAction false, so SPACE can never activate a row);
+         nothing paints because fs25_wideButton's own background is emptyPanel-transparent, the icon
+         is sized away and the label is empty. -->
+    <Profile name="RF_CtRowHit" extends="RF_CsPivotBtn">
+        <size value="530px 24px"/>
+        <iconSize value="0px 0px"/>
+        <textSize value="1px"/>
+    </Profile>
+
     <!-- BUILD 11:40 (George CLOSED DESIGN 11:25): the in-card herd / milk breed lists on the Dairy cards.
          20px rows = four visible in the 80px box (today's density); the slider shows only when rows overflow. -->
     <Profile name="RF_DairyBreedList" extends="RF_SmoothList">


### PR DESCRIPTION
## Summary
- Leftover eight-row hairlines on the shared Realistic Farming page stay hidden.

## Test plan
- [ ] Full restart. Esc Tax: no ghost eight-row table.
