### PR TITLE
feat(tax): RSF-F224 named-month calendar, annual cash bill and the loan read

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -86,8 +86,10 @@ local ledger = { farms = {} }
 FS25TaxMod.ledger = ledger
 
 local lastDay = -1
-local lastMonth = -1
+local lastMonth = -1        -- legacy mirror (the mapped calendar month, for display/save)
+local lastPeriod = -1       -- F224: the native period is the real change-detection gate
 local lastMinuteCheck = -1
+local _initialDueCheckPending = false  -- F224: settle March on first ready check after load
 local isInitialized = false
 local infoNotificationTimer = nil
 local taxHUD = nil
@@ -123,6 +125,66 @@ end
 local function getAnnualTaxRate()
     return (settings.annualTaxRate or 0.05) * _spineScale(FS25TaxMod.SPINE_ANNUAL_TAX)
 end
+
+-- =========================================================
+-- F224: native period -> calendar-month adapter
+-- =========================================================
+-- The engine publishes env.currentPeriod (1-12 season periods), NOT env.currentMonth
+-- (which does not exist), so the old month checks never fired. March (payment, month 3)
+-- and December (advisory, month 12) are NAMED months, not those numeric periods. Build
+-- the period->month bijection by matching the localized period label g_i18n:formatPeriod
+-- (which already accounts for latitude/hemisphere) against the ui_month1..12 texts. No
+-- hardcoded arithmetic, no English parsing. An ambiguous or incomplete map is UNAVAILABLE
+-- (retain accrual, make no guessed collection). Rebuilt when language/latitude changes.
+local _periodMonthMap = nil
+local _periodMonthMapKey = nil
+
+local function _calendarContextKey()
+    local env = g_currentMission and g_currentMission.environment
+    local lat = (env and env.daylight and env.daylight.latitude) or 0
+    -- ui_month1 label doubles as a cheap language probe: it changes with the locale.
+    local probe = (g_i18n ~= nil and g_i18n.getText ~= nil) and g_i18n:getText("ui_month1") or "?"
+    return (lat < 0 and "S" or "N") .. ":" .. tostring(probe)
+end
+
+local function _buildPeriodMonthMap()
+    if g_i18n == nil or g_i18n.formatPeriod == nil or g_i18n.getText == nil then return nil end
+    local monthName = {}
+    for m = 1, 12 do
+        local key = "ui_month" .. m
+        if g_i18n.hasText ~= nil and not g_i18n:hasText(key) then return nil end
+        monthName[m] = g_i18n:getText(key)
+    end
+    local map, usedMonth = {}, {}
+    for p = 1, 12 do
+        local label = nil
+        pcall(function() label = g_i18n:formatPeriod(p, false) end)
+        if label == nil then return nil end
+        local found = nil
+        for m = 1, 12 do
+            if label == monthName[m] then
+                if found ~= nil then return nil end  -- ambiguous label
+                found = m
+            end
+        end
+        if found == nil or usedMonth[found] then return nil end  -- unknown label / not a bijection
+        map[p], usedMonth[found] = found, true
+    end
+    return map
+end
+
+--- The calendar month (1-12, March=3) for a native period, or nil when the mapping is
+--- unavailable/ambiguous. Cached; rebuilt on a language/latitude context change.
+local function _periodMonth(period)
+    local key = _calendarContextKey()
+    if _periodMonthMap == nil or _periodMonthMapKey ~= key then
+        _periodMonthMap = _buildPeriodMonthMap()
+        _periodMonthMapKey = key
+    end
+    if _periodMonthMap == nil or type(period) ~= "number" then return nil end
+    return _periodMonthMap[period]
+end
+FS25TaxMod._periodMonth = _periodMonth  -- exposed for the contract test
 
 -- Real farm ids only (reject spectator / guided tour / invalid). Same shape as DairyCore F75.
 local function _isRealFarmId(farmId)
@@ -167,8 +229,12 @@ local function _ensureFarmTax(farmId)
     end
     local ft = stats.farmTax[farmId]
     if ft == nil then
-        ft = { taxesAccumulatedAnnual = 0, daysTaxed = 0, lastTaxYear = 0 }
+        -- `imported` holds per-origin buckets merged in by an MP->SP conversion, each
+        -- keeping its own acc + paidYear guard (never collapsed into the active bucket).
+        ft = { taxesAccumulatedAnnual = 0, daysTaxed = 0, lastTaxYear = 0, imported = {} }
         stats.farmTax[farmId] = ft
+    elseif ft.imported == nil then
+        ft.imported = {}
     end
     return ft
 end
@@ -190,7 +256,46 @@ local function _migrateLegacyAccrual()
         taxesAccumulatedAnnual = acc,
         daysTaxed = days,
         lastTaxYear = year,
+        imported = {},
     }
+end
+
+-- F224: apply the native g_farmManager.mergedFarms (old -> surviving) map to OUR tax
+-- buckets once. Native cash/loan pooling already happened in the engine; this keeps each
+-- origin's accumulator + paid-year guard as a SEPARATE imported bucket under the surviving
+-- farm (differing lastTaxYear values are never collapsed into one). Idempotent: a mapped
+-- origin is consumed, so a repeat map or restore cannot add the same obligation twice.
+local function _remapMergedFarms()
+    local fm = g_farmManager
+    local map = (fm ~= nil) and fm.mergedFarms or nil
+    if type(map) ~= "table" or next(map) == nil then return end
+    if type(stats.farmTax) ~= "table" then return end
+
+    for oldFarmId, target in pairs(map) do
+        if target ~= nil and target ~= oldFarmId and _isRealFarmId(target) then
+            local src = stats.farmTax[oldFarmId]
+            if src ~= nil then
+                stats.farmTax[oldFarmId] = nil
+                local dst = _ensureFarmTax(target)
+                -- The old farm's active accumulator becomes an imported bucket carrying
+                -- its own paid-year guard; its own imported buckets carry over unchanged.
+                if (src.taxesAccumulatedAnnual or 0) > 0 or (src.lastTaxYear or 0) > 0 then
+                    dst.imported[#dst.imported + 1] = {
+                        acc          = src.taxesAccumulatedAnnual or 0,
+                        paidYear     = src.lastTaxYear or 0,
+                        originFarmId = oldFarmId,
+                    }
+                end
+                for _, b in ipairs(src.imported or {}) do
+                    dst.imported[#dst.imported + 1] = {
+                        acc          = b.acc or 0,
+                        paidYear     = b.paidYear or 0,
+                        originFarmId = b.originFarmId or oldFarmId,
+                    }
+                end
+            end
+        end
+    end
 end
 
 local function getSettingsPath()
@@ -203,6 +308,14 @@ end
 local function saveSettings()
     local path = getSettingsPath()
     if not path then return end
+    -- F224/F179: ensure the modSettings destination under the active save directory
+    -- exists before writing (createXMLFile fails silently if the folder is missing).
+    if g_currentMission and g_currentMission.missionInfo
+       and g_currentMission.missionInfo.savegameDirectory then
+        pcall(function()
+            createFolder(g_currentMission.missionInfo.savegameDirectory .. "/modSettings")
+        end)
+    end
     local xmlFile = createXMLFile("taxSettings", path, "settings")
     if xmlFile == 0 then return end
     setXMLBool(xmlFile,   "settings.enabled",          settings.enabled)
@@ -231,6 +344,15 @@ local function saveSettings()
             setXMLInt(xmlFile, key .. "#accumulated", ft.taxesAccumulatedAnnual or 0)
             setXMLInt(xmlFile, key .. "#daysTaxed", ft.daysTaxed or 0)
             setXMLInt(xmlFile, key .. "#lastTaxYear", ft.lastTaxYear or 0)
+            -- F224: imported per-origin buckets from an MP->SP merge (own paid-year guard).
+            local bi = 0
+            for _, b in ipairs(ft.imported or {}) do
+                local bkey = string.format("%s.bucket(%d)", key, bi)
+                setXMLInt(xmlFile, bkey .. "#acc", b.acc or 0)
+                setXMLInt(xmlFile, bkey .. "#paidYear", b.paidYear or 0)
+                if b.originFarmId ~= nil then setXMLInt(xmlFile, bkey .. "#originFarmId", b.originFarmId) end
+                bi = bi + 1
+            end
             farmTaxIndex = farmTaxIndex + 1
         end
     end
@@ -280,11 +402,25 @@ local function loadSettings()
         local key = string.format("settings.farmTax.farm(%d)", farmTaxIndex)
         local farmId = getXMLInt(xmlFile, key .. "#farmId")
         if farmId == nil then break end
-        stats.farmTax[farmId] = {
+        local ft = {
             taxesAccumulatedAnnual = Utils.getNoNil(getXMLInt(xmlFile, key .. "#accumulated"), 0),
             daysTaxed = Utils.getNoNil(getXMLInt(xmlFile, key .. "#daysTaxed"), 0),
             lastTaxYear = Utils.getNoNil(getXMLInt(xmlFile, key .. "#lastTaxYear"), 0),
+            imported = {},
         }
+        local bi = 0
+        while true do
+            local bkey = string.format("%s.bucket(%d)", key, bi)
+            local acc = getXMLInt(xmlFile, bkey .. "#acc")
+            if acc == nil then break end
+            ft.imported[#ft.imported + 1] = {
+                acc          = acc,
+                paidYear     = Utils.getNoNil(getXMLInt(xmlFile, bkey .. "#paidYear"), 0),
+                originFarmId = getXMLInt(xmlFile, bkey .. "#originFarmId"),
+            }
+            bi = bi + 1
+        end
+        stats.farmTax[farmId] = ft
         farmTaxIndex = farmTaxIndex + 1
     end
     ledger.farms = {}
@@ -332,10 +468,15 @@ function FS25TaxMod.serializeState()
     local farmTax = {}
     if type(stats.farmTax) == "table" then
         for farmId, ft in pairs(stats.farmTax) do
+            local imported = {}
+            for i, b in ipairs(ft.imported or {}) do
+                imported[i] = { acc = b.acc or 0, paidYear = b.paidYear or 0, originFarmId = b.originFarmId }
+            end
             farmTax[farmId] = {
                 taxesAccumulatedAnnual = ft.taxesAccumulatedAnnual or 0,
                 daysTaxed = ft.daysTaxed or 0,
                 lastTaxYear = ft.lastTaxYear or 0,
+                imported = imported,
             }
         end
     end
@@ -374,10 +515,23 @@ function FS25TaxMod.applyState(data)
             for farmId, ft in pairs(st.farmTax) do
                 local fid = tonumber(farmId)
                 if fid ~= nil and type(ft) == "table" then
+                    local imported = {}
+                    if type(ft.imported) == "table" then
+                        for _, b in ipairs(ft.imported) do
+                            if type(b) == "table" then
+                                imported[#imported + 1] = {
+                                    acc          = tonumber(b.acc) or 0,
+                                    paidYear     = tonumber(b.paidYear) or 0,
+                                    originFarmId = tonumber(b.originFarmId),
+                                }
+                            end
+                        end
+                    end
                     stats.farmTax[fid] = {
                         taxesAccumulatedAnnual = tonumber(ft.taxesAccumulatedAnnual) or 0,
                         daysTaxed = tonumber(ft.daysTaxed) or 0,
                         lastTaxYear = tonumber(ft.lastTaxYear) or 0,
+                        imported = imported,
                     }
                 end
             end
@@ -500,41 +654,59 @@ local function applyAnnualTax()
         end
     end)
 
-    local anyPaid = false
+    local annualRate = getAnnualTaxRate()
     for _, farmId in ipairs(farmIds) do
         local ft = _ensureFarmTax(farmId)
-        if (ft.lastTaxYear or 0) < currentYear then
-            if (ft.taxesAccumulatedAnnual or 0) <= 0 then
-                log(string.format("No annual tax accumulated for farm %d. Marking year processed.", farmId), 2)
-                ft.lastTaxYear = currentYear
-            else
-                local taxAmount = math.floor(ft.taxesAccumulatedAnnual * getAnnualTaxRate())
-                if taxAmount <= 0 then
-                    log(string.format("Calculated annual tax is zero for farm %d. Resetting.", farmId), 2)
-                    ft.taxesAccumulatedAnnual = 0
-                    ft.lastTaxYear = currentYear
-                else
-                    -- Only the server may move money; engine syncs balance to clients.
-                    -- Explicit farmId — never getFarmId() as dedicated authority.
-                    if isServer then
-                        g_currentMission:addMoney(-taxAmount, farmId, MoneyType.OTHER, true)
-                    end
-                    stats.totalTaxesPaid = (stats.totalTaxesPaid or 0) + taxAmount
-                    ft.taxesAccumulatedAnnual = 0
-                    ft.lastTaxYear = currentYear
+        local farmTax = 0          -- one cash event per farm; each bucket floored separately
+        local anyBucketDue = false
 
-                    if localFarmId ~= nil and farmId == localFarmId then
-                        stats.taxesAccumulatedAnnual = 0
-                        stats.lastTaxYear = currentYear
-                        if taxHUD then
-                            taxHUD:recordTax(taxAmount, 1, stats.taxReturnMonth, true)
-                        end
-                        if settings.showNotification then
-                            g_currentMission:addIngameNotification({1.0, 0.0, 0.0, 1.0},
-                                string.format("Annual tax deducted for %d: -%s", currentYear - 1, formatMoney(taxAmount)))
-                        end
-                    end
+        -- Active bucket: due once per year by its own guard.
+        if (ft.lastTaxYear or 0) < currentYear then
+            anyBucketDue = true
+            if (ft.taxesAccumulatedAnnual or 0) > 0 then
+                farmTax = farmTax + math.floor(ft.taxesAccumulatedAnnual * annualRate)
+            end
+            ft.taxesAccumulatedAnnual = 0
+            ft.lastTaxYear = currentYear
+        end
+
+        -- Imported buckets (MP->SP): each priced and guarded independently, then folded
+        -- into this farm's single charge. An already-paid imported bucket is not billed
+        -- again; its later accrual waits for its own next eligible year.
+        for _, b in ipairs(ft.imported or {}) do
+            if (b.paidYear or 0) < currentYear then
+                anyBucketDue = true
+                if (b.acc or 0) > 0 then
+                    farmTax = farmTax + math.floor(b.acc * annualRate)
                 end
+                b.acc = 0
+                b.paidYear = currentYear
+            end
+        end
+
+        if farmTax > 0 then
+            -- Only the server moves money; engine syncs balance to clients. Explicit
+            -- farmId — never getFarmId() as dedicated authority.
+            if isServer then
+                g_currentMission:addMoney(-farmTax, farmId, MoneyType.OTHER, true)
+            end
+            stats.totalTaxesPaid = (stats.totalTaxesPaid or 0) + farmTax
+            if localFarmId ~= nil and farmId == localFarmId then
+                stats.taxesAccumulatedAnnual = 0
+                stats.lastTaxYear = currentYear
+                if taxHUD then
+                    taxHUD:recordTax(farmTax, 1, stats.taxReturnMonth, true)
+                end
+                if settings.showNotification then
+                    g_currentMission:addIngameNotification({1.0, 0.0, 0.0, 1.0},
+                        string.format("Annual tax deducted for %d: -%s", currentYear - 1, formatMoney(farmTax)))
+                end
+            end
+        elseif anyBucketDue then
+            log(string.format("Farm %d: year %d processed, no tax owed.", farmId, currentYear), 2)
+            if localFarmId ~= nil and farmId == localFarmId then
+                stats.taxesAccumulatedAnnual = 0
+                stats.lastTaxYear = currentYear
             end
         end
     end
@@ -555,6 +727,110 @@ local function applyAnnualTax()
     end
 
     saveSettings()
+end
+
+-- =========================================================
+-- F224 / C3: pure tax cash-bill reader (for the emergency-loan forecast)
+-- =========================================================
+FS25TaxMod.TAX_PROJECTION_VERSION = 1
+
+--- DOT function on mission.taxManager (FS25TaxMod). Server-only and PURE: it never
+--- advances taxable state, settles, saves or mutates cursors. Given C3's ascending
+--- daily scenario on its tax-free baseline, TaxMod alone maps period->March, applies
+--- future daily accrual ONCE into the active bucket, prices each eligible bucket
+--- (active + imported) with its own floor + paid-year guard, and emits ONE annual cash
+--- event at the first eligible March (then stops). Already-due-at-asOf quotes current
+--- accrued (no invented current-day accrual; labelled a lower bound). Returns a copied
+--- version-1 snapshot that never aliases live state (F224 directions 5-9).
+---@param farmId number
+---@param scenario table  ascending { {monotonicDay, timeOfDayMs, year, period, balance, isFuture}, ... }
+---@return table  version-1 tax projection snapshot
+function FS25TaxMod.getLoanTaxProjection(farmId, scenario)
+    local result = {
+        version               = FS25TaxMod.TAX_PROJECTION_VERSION,
+        status                = "UNAVAILABLE",
+        farmId                = farmId,
+        dueCalendar           = nil,
+        dueDay                = nil,
+        dueTimeMs             = nil,
+        accruedCashDue        = nil,
+        futureAccrualIncluded = false,
+        cashEvents            = {},
+        coverageReasons       = {},
+    }
+    local function gap(r) result.coverageReasons[#result.coverageReasons + 1] = r end
+
+    -- DOT contract: a colon call passes the module table as farmId. Reject it (and any
+    -- non-number) without guessing a farm.
+    if farmId == FS25TaxMod or type(farmId) ~= "number" then gap("BAD_CALL"); return result end
+    if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
+        gap("NOT_SERVER"); return result
+    end
+    if not _isRealFarmId(farmId) then gap("INVALID_FARM"); return result end
+    if not settings.enabled then
+        -- Healthy disabled: no scheduled charge, stored accrual preserved.
+        result.status = "OK"; gap("TAX_DISABLED"); return result
+    end
+
+    -- Copy this farm's active accumulator + guard and every imported bucket (pure).
+    local ft = stats.farmTax and stats.farmTax[farmId]
+    local buckets = {}
+    buckets[1] = { acc = (ft and ft.taxesAccumulatedAnnual) or 0, paidYear = (ft and ft.lastTaxYear) or 0 }
+    if ft ~= nil then
+        for _, b in ipairs(ft.imported or {}) do
+            buckets[#buckets + 1] = { acc = b.acc or 0, paidYear = b.paidYear or 0 }
+        end
+    end
+
+    local dailyRate  = getTaxRate()
+    local annualRate = getAnnualTaxRate()
+    local minBalance = settings.minimumBalance or 0
+    local futureAccrual = false
+
+    for _, day in ipairs(scenario or {}) do
+        -- Future daily accrual: once, into the active bucket, above the minimum balance.
+        if day.isFuture == true and type(day.balance) == "number" and day.balance >= minBalance then
+            local add = math.floor(day.balance * dailyRate)
+            if add > 0 then
+                buckets[1].acc = buckets[1].acc + add
+                futureAccrual = true
+            end
+        end
+
+        -- Annual due at the first mapped March in the horizon.
+        local mappedMonth = day.month or _periodMonth(day.period)
+        if mappedMonth == stats.taxReturnMonth then
+            local cash, eligible = 0, false
+            for _, b in ipairs(buckets) do
+                if (b.paidYear or 0) < (day.year or 0) then
+                    eligible = true
+                    cash = cash + math.floor((b.acc or 0) * annualRate)  -- per-bucket floor
+                    b.acc, b.paidYear = 0, day.year
+                end
+            end
+            if eligible then
+                result.status                = "OK"
+                result.futureAccrualIncluded = futureAccrual
+                result.dueDay                = day.monotonicDay
+                result.dueTimeMs             = day.timeOfDayMs
+                result.dueCalendar           = { year = day.year, period = day.period, month = mappedMonth }
+                result.cashEvents[1] = {
+                    year = day.year, amount = cash,
+                    dueDay = day.monotonicDay, dueTimeMs = day.timeOfDayMs, basis = "ANNUAL_MARCH",
+                }
+                return result  -- one event; the owner stops at its first due March
+            end
+        end
+    end
+
+    -- No eligible March inside the horizon: report the current accrued lower bound.
+    local accruedCash = 0
+    for _, b in ipairs(buckets) do accruedCash = accruedCash + math.floor((b.acc or 0) * annualRate) end
+    result.accruedCashDue        = accruedCash
+    result.futureAccrualIncluded = futureAccrual
+    if not futureAccrual then gap("ACCRUAL_LOWER_BOUND") end
+    result.status = (#result.coverageReasons > 0) and "PARTIAL" or "OK"
+    return result
 end
 
 local function taxAdvisory()
@@ -617,6 +893,16 @@ local function createUpdateable()
                     local env = g_currentMission.environment
                     local currentYear = env.currentYear or 0
 
+                    -- F224: settle March on the first ready check after load/enable (the
+                    -- owner due check also runs on a period change below). One-shot.
+                    if _initialDueCheckPending then
+                        _initialDueCheckPending = false
+                        local m0 = _periodMonth(env.currentPeriod)
+                        if m0 == stats.taxReturnMonth and currentYear > (stats.lastTaxYear or 0) then
+                            applyAnnualTax()
+                        end
+                    end
+
                     -- Daily tax accumulation
                     if env.currentDay ~= lastDay then
                         lastDay = env.currentDay
@@ -629,19 +915,27 @@ local function createUpdateable()
                         end
                     end
 
-                    -- Monthly checks for annual tax events
-                    if env.currentMonth ~= lastMonth then
-                        lastMonth = env.currentMonth
+                    -- F224: annual-tax events gate on the NATIVE PERIOD change (env.currentMonth
+                    -- does not exist in the engine — the old check never fired), mapped to the
+                    -- named calendar month. March (3) pays, December (12) advises.
+                    if env.currentPeriod ~= lastPeriod then
+                        lastPeriod = env.currentPeriod
+                        local mappedMonth = _periodMonth(env.currentPeriod)
+                        if mappedMonth ~= nil then
+                            lastMonth = mappedMonth  -- legacy mirror: the named calendar month
 
-                        -- December Tax Advisory
-                        if lastMonth == stats.taxAdvisoryMonth then
-                            taxAdvisory()
-                        end
+                            -- December Tax Advisory.
+                            if mappedMonth == stats.taxAdvisoryMonth then
+                                taxAdvisory()
+                            end
 
-                        -- March Annual Tax Payment (for the previous year)
-                        if lastMonth == stats.taxReturnMonth and currentYear > (stats.lastTaxYear or 0) then
-                            applyAnnualTax()
+                            -- March Annual Tax Payment (for the previous year).
+                            if mappedMonth == stats.taxReturnMonth and currentYear > (stats.lastTaxYear or 0) then
+                                applyAnnualTax()
+                            end
                         end
+                        -- mappedMonth == nil -> mapping unavailable: retain accrual and make no
+                        -- guessed collection; the period gate advances to re-check next period.
                     end
                 end
             end
@@ -954,9 +1248,19 @@ local function onMissionLoaded(mission, node)
 
     local env = g_currentMission.environment
     if env then
-        lastDay         = tonumber(env.currentDay)   or 1
-        lastMonth       = tonumber(env.currentMonth) or 1
+        lastDay         = tonumber(env.currentDay)    or 1
+        lastPeriod      = tonumber(env.currentPeriod) or -1
+        lastMonth       = _periodMonth(env.currentPeriod) or lastMonth  -- mapped calendar month
         lastMinuteCheck = math.floor((env.dayTime or 0) / 60000)
+    end
+
+    -- F224: settle March on the first update after load (direction 3), and apply any
+    -- native MP->SP farm conversion once now that native farms + the merge map exist
+    -- (loadMission00Finished runs after FarmManager load). Server-only; a repeat map
+    -- cannot double-pool because a mapped origin is consumed.
+    _initialDueCheckPending = true
+    if g_currentMission:getIsServer() then
+        _remapMergedFarms()
     end
 
     if taxHUD then
@@ -1068,7 +1372,9 @@ FSBaseMission.draw = Utils.appendedFunction(FSBaseMission.draw, function(mission
     end
 end)
 
-Mission00.saveToXMLFile = Utils.appendedFunction(Mission00.saveToXMLFile, function(mission, xmlFilename)
+-- F224/F179: persist on the career-save event (the active save window the engine
+-- commits in) rather than Mission00.saveToXMLFile. HUD layout stays client-local.
+FSCareerMissionInfo.saveToXMLFile = Utils.appendedFunction(FSCareerMissionInfo.saveToXMLFile, function(missionInfo)
     saveSettings()
     if taxHUD then taxHUD:saveLayout() end
 end)

--- a/tools/test/lib.mjs
+++ b/tools/test/lib.mjs
@@ -1,0 +1,42 @@
+// Shared helpers for the FS25_SoilFertilizer test tooling.
+import { readdirSync, statSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// Repo root is two levels up from tools/test/
+export const REPO_ROOT = resolve(__dirname, "..", "..");
+export const SRC_DIR = join(REPO_ROOT, "src");
+
+/** Recursively collect every *.lua file under `dir`. */
+export function findLuaFiles(dir = SRC_DIR) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...findLuaFiles(full));
+    } else if (entry.endsWith(".lua")) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+/** Path relative to repo root, with forward slashes (clickable in terminals). */
+export function rel(p) {
+  return relative(REPO_ROOT, p).replace(/\\/g, "/");
+}
+
+// Minimal ANSI colour (skipped when not a TTY).
+const useColor = process.stdout.isTTY;
+const wrap = (code) => (s) => (useColor ? `\x1b[${code}m${s}\x1b[0m` : s);
+export const c = {
+  red: wrap("31"),
+  green: wrap("32"),
+  yellow: wrap("33"),
+  cyan: wrap("36"),
+  dim: wrap("2"),
+  bold: wrap("1"),
+};

--- a/tools/test/lua/RSF-F224-tax_cashflow_contract_test.lua
+++ b/tools/test/lua/RSF-F224-tax_cashflow_contract_test.lua
@@ -1,0 +1,161 @@
+--!load: main.lua
+-- RSF-F224 contract test, retargeted at the REAL repaired producer (FS25TaxMod).
+-- The delivered draft was pure reference ("the actual owner functions are not
+-- implemented"); per its instruction the scenarios are now bound to the real
+-- FS25TaxMod._periodMonth (calendar adapter) and FS25TaxMod.getLoanTaxProjection
+-- (pure cash-bill reader). Pure-arithmetic counterexamples that have no owner function
+-- to bind to are retained as reference models and labelled REFERENCE.
+-- Not proven here: native XML/save, real southern runtime labels, actual cash transfer,
+-- Time Guard, GUI. Those are in-game observations.
+
+T.ok("F224 setup: FS25TaxMod loaded", type(FS25TaxMod) == "table")
+T.ok("F224 setup: real getLoanTaxProjection present", type(FS25TaxMod.getLoanTaxProjection) == "function")
+T.ok("F224 setup: real _periodMonth present", type(FS25TaxMod._periodMonth) == "function")
+
+-- Default settings already match the contract's terms: daily 0.02 (medium), annual 0.05,
+-- minimum 1000. _spineScale is neutral (no SettingsHub), so the real rates are used.
+local mission = {
+    environment = { currentYear = 1, currentPeriod = 1, currentDay = 1,
+        currentMonotonicDay = 1, currentDayInPeriod = 1, daysPerPeriod = 3, dayTime = 0,
+        daylight = { latitude = 0.5 } },  -- northern
+    getFarmId   = function() return nil end,   -- dedicated: no local-farm notify/HUD path
+    getIsServer = function() return true end,
+    addMoney    = function() end,
+    missionInfo = {},                          -- no savegameDirectory => saveSettings no-ops
+}
+g_currentMission = mission
+
+-- ── GROUP A: the REAL period -> calendar-month adapter ──────────────────────────
+T.eq("F224 A1 REAL period 1 maps to March (3)",  FS25TaxMod._periodMonth(1),  3)
+T.eq("F224 A2 REAL period 3 maps to May (5)",    FS25TaxMod._periodMonth(3),  5)
+T.eq("F224 A3 REAL period 10 maps to December (12)", FS25TaxMod._periodMonth(10), 12)
+T.eq("F224 A4 REAL period 11 wraps to January (1)", FS25TaxMod._periodMonth(11), 1)
+
+-- Hemisphere change busts the cache; the adapter rebuilds from the new formatPeriod.
+mission.environment.daylight.latitude = -0.5
+g_i18n.formatPeriod = function(_self, period)
+    if type(period) ~= "number" then return nil end
+    return "ui_month" .. (((period + 7) % 12) + 1)  -- synthetic southern output
+end
+T.eq("F224 A5 REAL southern rebuild follows formatPeriod output", FS25TaxMod._periodMonth(1), 9)
+-- Restore northern for the projection group.
+mission.environment.daylight.latitude = 0.5
+g_i18n.formatPeriod = function(_self, period)
+    if type(period) ~= "number" then return nil end
+    return "ui_month" .. (((period + 1) % 12) + 1)
+end
+
+-- REFERENCE: bijection rejection (ambiguous / unknown label). Models _buildPeriodMonthMap's
+-- rejection logic, which has no standalone owner entry point to bind to.
+local function monthMap(labels, monthNames)
+    local result, used = {}, {}
+    for period = 1, 12 do
+        local found = nil
+        for month = 1, 12 do
+            if labels[period] == monthNames[month] then
+                if found ~= nil then return nil end
+                found = month
+            end
+        end
+        if found == nil or used[found] then return nil end
+        result[period], used[found] = found, true
+    end
+    return result
+end
+local names, north = {}, {}
+for i = 1, 12 do names[i] = "month-key-" .. i end
+for i = 1, 12 do north[i] = names[((i + 1) % 12) + 1] end
+T.eq("F224 A6 REFERENCE northern bijection builds", monthMap(north, names)[1], 3)
+local duplicate = {}; for i = 1, 12 do duplicate[i] = north[i] end; duplicate[2] = duplicate[1]
+T.eq("F224 A7 REFERENCE ambiguous mapping refuses", monthMap(duplicate, names), nil)
+local missing = {}; for i = 1, 12 do missing[i] = north[i] end; missing[2] = "unknown"
+T.eq("F224 A8 REFERENCE unknown label refuses", monthMap(missing, names), nil)
+
+-- ── GROUP B: the REAL pure cash-bill reader (getLoanTaxProjection) ───────────────
+local function setFarm(acc, paidYear, imported)
+    FS25TaxMod.stats.farmTax = FS25TaxMod.stats.farmTax or {}
+    FS25TaxMod.stats.farmTax[7] = {
+        taxesAccumulatedAnnual = acc, daysTaxed = 0, lastTaxYear = paidYear, imported = imported or {},
+    }
+end
+-- Scenario samples carry the NATIVE period; the reader maps it to the named month.
+local P_MARCH, P_APRIL = 1, 2  -- _periodMonth(1)=3 (March), _periodMonth(2)=4 (April)
+
+setFarm(20000, 0)
+local r1 = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = false, period = P_MARCH, year = 1, balance = 500, monotonicDay = 100, timeOfDayMs = 0 } })
+T.eq("F224 B1 accrued basis becomes the cash bill, not the raw accumulator", r1.cashEvents[1] and r1.cashEvents[1].amount, 1000)
+T.eq("F224 B2 read does not reset the live accumulator", FS25TaxMod.stats.farmTax[7].taxesAccumulatedAnnual, 20000)
+T.eq("F224 B3 read does not advance the live paid year", FS25TaxMod.stats.farmTax[7].lastTaxYear, 0)
+T.eq("F224 B4 annual bill is not capped by current cash", (r1.cashEvents[1].amount > 500), true)
+T.eq("F224 B5 read carries the due-day field", r1.cashEvents[1].dueDay, 100)
+T.eq("F224 B6 read status OK", r1.status, "OK")
+
+local same = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = false, period = P_MARCH, year = 1, balance = 500, monotonicDay = 100, timeOfDayMs = 0 } })
+T.eq("F224 B7 repeat read quotes the same bill without settling", same.cashEvents[1].amount, 1000)
+
+local r2 = FS25TaxMod.getLoanTaxProjection(7, {
+    { isFuture = true, period = P_MARCH, year = 1, balance = 100000, monotonicDay = 100, timeOfDayMs = 0 },
+    { isFuture = true, period = P_MARCH, year = 1, balance = 100000, monotonicDay = 101, timeOfDayMs = 0 },
+})
+T.eq("F224 B8 daily accumulation precedes the annual price", r2.cashEvents[1].amount, 1100)
+T.eq("F224 B9 one cash event for repeated March days", #r2.cashEvents, 1)
+T.eq("F224 B10 future accrual is flagged", r2.futureAccrualIncluded, true)
+
+setFarm(5000, 1)
+local paid = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = true, period = P_MARCH, year = 1, balance = 100000, monotonicDay = 100, timeOfDayMs = 0 } })
+T.eq("F224 B11 a processed paid-year guard suppresses the bill", #paid.cashEvents, 0)
+
+setFarm(20000, 0)
+FS25TaxMod.settings.enabled = false
+local off = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = true, period = P_MARCH, year = 1, balance = 100000, monotonicDay = 100, timeOfDayMs = 0 } })
+T.eq("F224 B12 disabled has no scheduled cash event", #off.cashEvents, 0)
+T.eq("F224 B13 disabled retains the accumulated obligation", FS25TaxMod.stats.farmTax[7].taxesAccumulatedAnnual, 20000)
+FS25TaxMod.settings.enabled = true
+
+local skip = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = true, period = P_APRIL, year = 4, balance = 0, monotonicDay = 200, timeOfDayMs = 0 } })
+T.eq("F224 B14 a skip past March does not replay missed years", #skip.cashEvents, 0)
+T.eq("F224 B15 skip retains the accrued state", FS25TaxMod.stats.farmTax[7].taxesAccumulatedAnnual, 20000)
+
+local nextMar = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = true, period = P_MARCH, year = 5, balance = 0, monotonicDay = 300, timeOfDayMs = 0 } })
+T.eq("F224 B16 the next real March bills the accumulator once", nextMar.cashEvents[1].amount, 1000)
+T.eq("F224 B17 no multiplication by missed years", #nextMar.cashEvents, 1)
+
+-- Per-bucket flooring on the real reader (pooled MP->SP buckets): floor each, then sum.
+setFarm(30, 1, { { acc = 30, paidYear = 1 } })
+local frac = FS25TaxMod.getLoanTaxProjection(7, { { isFuture = false, period = P_MARCH, year = 2, balance = 500, monotonicDay = 101, timeOfDayMs = 0 } })
+T.eq("F224 B18 each retained bucket is floored before summing (2, not 3)", frac.cashEvents[1].amount, 2)
+T.eq("F224 B19 REFERENCE the combined-floor counterexample would overcharge", math.floor((30 + 30) * 0.05), 3)
+
+-- DOT vs COLON call contract: a colon call passes the module table as farmId.
+setFarm(20000, 0)
+local scenario = { { isFuture = true, period = P_MARCH, year = 1, balance = 1000, monotonicDay = 100, timeOfDayMs = 0 } }
+T.eq("F224 B20 dot call produces a real snapshot", FS25TaxMod.getLoanTaxProjection(7, scenario).status, "OK")
+T.eq("F224 B21 colon call is the wrong contract -> UNAVAILABLE", FS25TaxMod:getLoanTaxProjection(7, scenario).status, "UNAVAILABLE")
+T.eq("F224 B22 a non-number farm is UNAVAILABLE", FS25TaxMod.getLoanTaxProjection("x", scenario).status, "UNAVAILABLE")
+
+-- "Owner finds March inside the full horizon; later samples cannot change the bill."
+setFarm(20000, 0)
+local full = {
+    { isFuture = true, period = 12, year = 1, balance = 1000, monotonicDay = 98,  timeOfDayMs = 0 }, -- month 2
+    { isFuture = true, period = P_MARCH, year = 1, balance = 1000, monotonicDay = 99, timeOfDayMs = 0 },
+    { isFuture = true, period = P_APRIL, year = 1, balance = 999999, monotonicDay = 100, timeOfDayMs = 0 },
+}
+local quoted = FS25TaxMod.getLoanTaxProjection(7, full)
+T.eq("F224 B23 owner finds March inside the full horizon", #quoted.cashEvents, 1)
+T.eq("F224 B24 later samples cannot change the first bill", quoted.cashEvents[1].amount, 1002)
+
+-- ── REFERENCE counterexamples (pure arithmetic; no owner function to bind) ───────
+local cash, minCash = 500, 500
+for _, delta in ipairs({ -1000, 2000 }) do cash = cash + delta; minCash = math.min(minCash, cash) end
+T.eq("F224 C1 REFERENCE a known tax bill can precede a later receipt", minCash, -500)
+T.eq("F224 C2 REFERENCE a positive endpoint does not erase the earlier shortage", cash, 1500)
+do
+    local buckets = { { id = "a", farm = 1, acc = 10000, paidYear = 7 }, { id = "b", farm = 2, acc = 20000, paidYear = 6 } }
+    local map = { [2] = 1 }; for _, x in ipairs(buckets) do x.farm = map[x.farm] or x.farm end
+    local c = 0
+    for _, x in ipairs(buckets) do if x.paidYear < 7 then c = c + math.floor(x.acc * 0.05); x.acc = 0; x.paidYear = 7 end end
+    T.eq("F224 C3 REFERENCE pool charges only the source bucket not yet paid this year", c, 1000)
+    T.eq("F224 C4 REFERENCE the already-paid farm's later accumulator remains", buckets[1].acc, 10000)
+end
+
+T.summary()

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -1,0 +1,92 @@
+-- prelude.lua - minimal FS25 engine mock + tiny test framework for FS25_TaxMod.
+-- Loaded first by run-tests.mjs, before main.lua and the test file. TaxMod's main.lua
+-- is a monolithic entry point: it source()s sibling files and installs Mission00 /
+-- FSBaseMission hooks at load time, so this prelude stubs exactly that load surface.
+-- The real FS25TaxMod table (with .stats/.settings/.getLoanTaxProjection/._periodMonth)
+-- is populated once main.lua loads against these stubs.
+
+unpack = unpack or table.unpack
+
+-- FS25 OO helper.
+function Class(base)
+  local mt = {}
+  mt.__index = base or mt
+  return mt
+end
+
+-- Mod directory latch: main.lua concatenates modDirectory .. "src/..." for source(),
+-- so it must be a non-nil string even though source() is a no-op here.
+g_currentModDirectory = "./"
+g_currentModName = "FS25_TaxMod"
+g_modsDirectory = "./"
+
+-- source(): no-op. The sibling files (TaxHUD, bridges, RfEsc, ...) are not needed for
+-- the pure producer logic under test; their globals stay nil and are guarded at load.
+function source(_path) end
+
+-- Lifecycle classes whose methods main.lua assigns via Utils hooks. Plain tables; the
+-- hooks are never invoked in these offline tests.
+Mission00 = Mission00 or {}
+FSBaseMission = FSBaseMission or {}
+FSCareerMissionInfo = FSCareerMissionInfo or {}
+
+Utils = Utils or {}
+function Utils.prependedFunction(_old, new) return new end
+function Utils.appendedFunction(_old, new) return new end
+function Utils.getNoNil(v, d) if v == nil then return d else return v end end
+
+function addModEventListener(_l) end
+function addConsoleCommand(_n, _d, _f, _t) end
+function createFolder(_p) end
+
+-- Engine globals the functions under test may touch at call time.
+g_currentMission = nil  -- each test sets its own mission stub
+MoneyType = { OTHER = 3, AI = 1, WORKER_WAGES = 2 }
+FarmManager = { SPECTATOR_FARM_ID = 0, GUIDED_TOUR_FARM_ID = 14, INVALID_FARM_ID = 15 }
+
+Logging = { info = function() end, warning = function() end, error = function() end }
+
+-- i18n: getText echoes unique month labels; formatPeriod models the NORTHERN mapping
+-- period -> ((period+1) % 12) + 1 (period 1 => month 3 = March), matching the engine's
+-- real formatPeriod northern path. Tests that need the southern path override this.
+g_i18n = {
+  getText = function(_self, key) return key end,
+  hasText = function(_self, key)
+    if type(key) ~= "string" then return false end
+    return key:sub(1, 8) == "ui_month"
+  end,
+  formatPeriod = function(_self, period, _short)
+    if type(period) ~= "number" then return nil end
+    local month = ((period + 1) % 12) + 1
+    return "ui_month" .. month
+  end,
+  formatMoney = function(_self, amount) return "$" .. tostring(amount) end,
+}
+
+-- XML + misc globals (only reached if a test drives a save path; harmless stubs).
+function createXMLFile() return 0 end
+function loadXMLFile() return 0 end
+function saveXMLFile() end
+function fileExists() return false end
+function delete() end
+function setXMLInt() end
+function setXMLFloat() end
+function setXMLString() end
+function setXMLBool() end
+function getXMLInt() return nil end
+function getXMLFloat() return nil end
+function getXMLString() return nil end
+function getXMLBool() return nil end
+
+-- ── tiny test framework (same markers run-tests.mjs parses) ──
+T = { _pass = 0, _fail = 0 }
+local function _pass(name) T._pass = T._pass + 1; print("##TEST_PASS " .. name) end
+local function _fail(name, msg) T._fail = T._fail + 1; print("##TEST_FAIL " .. name .. " :: " .. tostring(msg)) end
+function T.ok(name, cond, msg) if cond then _pass(name) else _fail(name, msg or "expected truthy, got " .. tostring(cond)) end end
+function T.eq(name, got, want) if got == want then _pass(name) else _fail(name, "got " .. tostring(got) .. " want " .. tostring(want)) end end
+function T.near(name, got, want, tol)
+  tol = tol or 1e-6
+  if type(got) == "number" and math.abs(got - want) <= tol then _pass(name)
+  else _fail(name, "got " .. tostring(got) .. " want ~" .. tostring(want) .. " (tol " .. tol .. ")") end
+end
+function T.summary() print("##TEST_SUMMARY " .. T._pass .. " " .. T._fail) end

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Lua 5.1 pre-commit gate. Excluded from the mod zip with the rest of tools/.",
+  "description": "Lua 5.1 pre-commit gate + offline contract tests. Excluded from the mod zip with the rest of tools/.",
+  "scripts": {
+    "test": "node run-tests.mjs"
+  },
   "devDependencies": {
+    "fengari": "^0.1.4",
     "luaparse": "^0.3.1"
   }
 }

--- a/tools/test/run-tests.mjs
+++ b/tools/test/run-tests.mjs
@@ -1,0 +1,97 @@
+// run-tests.mjs - offline logic tests for FS25_SoilFertilizer.
+//
+// For each tools/test/lua/*_test.lua, builds a single Lua program of:
+//   prelude.lua  +  the src modules it declares  +  the test file  +  T.summary()
+// runs it in a fresh fengari (Lua) state, captures stdout, and parses the
+// ##TEST_PASS / ##TEST_FAIL / ##TEST_SUMMARY markers the framework emits.
+//
+// A test declares which real src files to load with a header line:
+//   --!load: src/config/Constants.lua, src/SoilFertilitySystem.lua
+//
+// Usage:  node run-tests.mjs
+// Exit:   0 = all assertions passed, 1 = any failure or Lua load error.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import fengari from "fengari";
+import { REPO_ROOT, rel, c } from "./lib.mjs";
+
+const { lua, lauxlib, lualib, to_luastring } = fengari;
+const LUA_DIR = fileURLToPath(new URL("./lua", import.meta.url));
+const prelude = readFileSync(join(LUA_DIR, "prelude.lua"), "utf8");
+
+function parseDeps(src) {
+  const m = src.match(/--!load:\s*(.+)/);
+  if (!m) return [];
+  return m[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// Run one Lua program string, return { rc, out } with stdout captured.
+function runLua(program) {
+  let out = "";
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => { out += s; return true; };
+  let rc, errMsg = "";
+  try {
+    const L = lauxlib.luaL_newstate();
+    lualib.luaL_openlibs(L);
+    rc = lauxlib.luaL_dostring(L, to_luastring(program));
+    if (rc !== lua.LUA_OK) {
+      errMsg = lua.lua_tojsstring(L, -1);
+    }
+  } finally {
+    process.stdout.write = orig;
+  }
+  return { rc, out, errMsg };
+}
+
+const testFiles = readdirSync(LUA_DIR).filter((f) => f.endsWith("_test.lua")).sort();
+if (testFiles.length === 0) {
+  console.log(c.yellow("No *_test.lua files found in tools/test/lua/."));
+  process.exit(0);
+}
+
+let totalPass = 0, totalFail = 0, hadError = false;
+
+for (const tf of testFiles) {
+  const testPath = join(LUA_DIR, tf);
+  const testSrc = readFileSync(testPath, "utf8");
+  const deps = parseDeps(testSrc);
+
+  const parts = [prelude];
+  for (const d of deps) {
+    try {
+      parts.push(`-- <<< ${d} >>>\n` + readFileSync(join(REPO_ROOT, d), "utf8"));
+    } catch {
+      console.log(c.red(`✗ ${tf}: cannot read declared dependency '${d}'`));
+      hadError = true;
+    }
+  }
+  parts.push(`-- <<< test: ${tf} >>>\n` + testSrc);
+  parts.push("\nT.summary()\n");
+
+  const { rc, out, errMsg } = runLua(parts.join("\n"));
+
+  if (rc !== 0) {
+    hadError = true;
+    console.log(c.red(`✗ ${c.bold(tf)} - Lua error while loading/running:`));
+    console.log(`  ${c.red(errMsg || "(no message)")}`);
+    continue;
+  }
+
+  const passes = [...out.matchAll(/^##TEST_PASS (.+)$/gm)].map((m) => m[1]);
+  const fails = [...out.matchAll(/^##TEST_FAIL (.+)$/gm)].map((m) => m[1]);
+  totalPass += passes.length;
+  totalFail += fails.length;
+
+  const status = fails.length === 0 ? c.green("✓") : c.red("✗");
+  console.log(`${status} ${c.bold(tf)} ${c.dim(`(${passes.length} passed, ${fails.length} failed)`)}`);
+  for (const f of fails) console.log(`    ${c.red("FAIL")} ${f}`);
+}
+
+console.log(
+  "\n" +
+    (totalFail === 0 && !hadError ? c.green("PASS") : c.red("FAIL")) +
+    ` - ${totalPass} assertion${totalPass === 1 ? "" : "s"} passed, ${totalFail} failed across ${testFiles.length} file${testFiles.length === 1 ? "" : "s"}.`
+);
+process.exit(totalFail === 0 && !hadError ? 0 : 1);


### PR DESCRIPTION
## RSF-F224 — tax dates and the loan cash-bill read

Owner repair for the annual tax cycle plus the pure read the **C3 / RSF-F130 emergency loan** consumes. The loan remains usable without this companion.

### The core bug
The monthly checks gated on `env.currentMonth` — **a field the engine does not publish** (it publishes `currentPeriod`). So the December advisory and March payment never fired.

### Repairs
- **Calendar adapter:** build a period→calendar-month **bijection** by matching `g_i18n:formatPeriod(period, false)` (hemisphere-correct) against the `ui_month1..12` texts, `hasText`-guarded. Ambiguous/missing ⇒ UNAVAILABLE (retain accrual, no guessed collection). `update()` now gates on the native **period change** → mapped named month: March (3) pays, December (12) advises. March also settles on the first ready check after load.
- **Reader:** new `FS25TaxMod.getLoanTaxProjection(farmId, scenario)` — a **dot** function on `mission.taxManager`, server-only and **pure**. Copies the active accumulator + every imported bucket, applies future daily accrual once into the active bucket, prices each eligible bucket with its own `math.floor` + paid-year guard, and emits **one** annual cash event at the first eligible March (already-due ⇒ current-accrual lower bound). Never settles, saves, or mutates live state.
- **Annual collection:** `applyAnnualTax` prices active + imported buckets per farm into one charge.
- **F179 save-hook:** `Mission00.saveToXMLFile` → guarded `FSCareerMissionInfo.saveToXMLFile`, ensuring the `modSettings` destination exists.
- **MP→SP conversion:** `g_farmManager.mergedFarms` remap keeps each origin's accumulator + paid-year guard as a **separate imported bucket** (differing `lastTaxYear` never collapsed), applied once on load; a repeat map cannot double-pool.
- **Persistence:** imported buckets round-trip through `save/loadSettings` and the StateLedger state twin.

### Verification
- Contract test retargeted to the **real** `_periodMonth` and `getLoanTaxProjection` (the delivered draft executed no source): **39 assertions, 0 failures** (fengari; `npm test`). Per-bucket floor proven (two pooled buckets of 30 owe 2, not 3); dot-vs-colon contract; purity (no live mutation).
- Every engine API verified against the decompiled source first (`currentMonth` absence, `formatPeriod` math, `FSCareerMissionInfo:saveToXMLFile`, `createFolder`). Lua 5.1 syntax gate green.

### Still owed to the release lane (in-game observations)
Native XML save/reload round-trip, real southern-hemisphere runtime labels, actual cash transfer, real MP→SP conversion, Time Guard cadence.
